### PR TITLE
class sanitization / rot axisDir fixup

### DIFF
--- a/anim2cfg.py
+++ b/anim2cfg.py
@@ -64,9 +64,13 @@ def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                 q = (curr @ last.inverted()).to_quaternion()
                 d = p - last.to_translation()
                 length = d.length
-                if length == 0:
+                if round(length, precision) == 0:
                     d = Vector((1, 0, 0))
                 dn = d.normalized()
+                q_axis = q.axis.normalized()
+                q_angle = degrees(q.angle)
+                if round(q_angle, precision) == 0:
+                    q_axis = Vector((1, 0, 0))
                 curr_min_value = min_value + i*(max_value - min_value)/(len(frames) - 1)
                 curr_max_value = min_value + (i + 1)*(max_value - min_value)/(len(frames) - 1)
                 cfg.write(f"class {sanitize_classname(selection_name)}_trans_{i} {{\n"
@@ -85,8 +89,8 @@ def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                           f"    source     = {source_name};\n"
                           f"    selection  = {selection_name};\n"
                           f"    axisPos[]  = {{{p.x:.{precision}f}, {p.z:.{precision}f}, {p.y:.{precision}f}}};\n"
-                          f"    axisDir[]  = {{{q.axis.x:.{precision}f}, {q.axis.z:.{precision}f}, {q.axis.y:.{precision}f}}};\n"
-                          f"    angle      = {degrees(q.angle):.{precision}f};\n"
+                          f"    axisDir[]  = {{{q_axis.x:.{precision}f}, {q_axis.z:.{precision}f}, {q_axis.y:.{precision}f}}};\n"
+                          f"    angle      = {q_angle:.{precision}f};\n"
                           f"    axisOffset = 0;\n"
                           f"    minValue   = {curr_min_value:.{precision}f};\n"
                           f"    maxValue   = {curr_max_value:.{precision}f};\n"

--- a/anim2cfg.py
+++ b/anim2cfg.py
@@ -38,7 +38,7 @@ def sanitize_classname(text):
 
 def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                 frame_start=0, frame_end=0, min_value=0.1, max_value=1.0,
-                precision=5):
+                precision=7):
     frames = range(frame_start, 1 + frame_end)
     last = None
     i = 0
@@ -138,7 +138,7 @@ class ANIM2CFG_OT_ModelCfgExport(bpy.types.Operator,
         name="Precision",
         description="Number of decimal places",
         min=0,
-        default=5)
+        default=7)
 
     def invoke(self, context, event):
         self.selection_name = bpy.context.active_object.name

--- a/anim2cfg.py
+++ b/anim2cfg.py
@@ -31,6 +31,10 @@ import bpy_extras
 from bpy.utils import register_class, unregister_class
 from math import degrees
 from mathutils import Matrix, Vector
+import re
+
+def sanitize_classname(text):
+    return re.sub('[^A-Za-z0-9_]', '_', text)
 
 def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                 frame_start=0, frame_end=0, min_value=0.1, max_value=1.0,
@@ -65,7 +69,7 @@ def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                 dn = d.normalized()
                 curr_min_value = min_value + i*(max_value - min_value)/(len(frames) - 1)
                 curr_max_value = min_value + (i + 1)*(max_value - min_value)/(len(frames) - 1)
-                cfg.write(f"class {selection_name}_trans_{i} {{\n"
+                cfg.write(f"class {sanitize_classname(selection_name)}_trans_{i} {{\n"
                           f"    type       = direct;\n"
                           f"    source     = {source_name};\n"
                           f"    selection  = {selection_name};\n"
@@ -76,7 +80,7 @@ def export_anim(file, obj, selection_name='', source_name='', parent_name='',
                           f"    minValue   = {curr_min_value:.{precision}f};\n"
                           f"    maxValue   = {curr_max_value:.{precision}f};\n"
                           f"}};\n"
-                          f"class {selection_name}_rot_{i} {{\n"
+                          f"class {sanitize_classname(selection_name)}_rot_{i} {{\n"
                           f"    type       = direct;\n"
                           f"    source     = {source_name};\n"
                           f"    selection  = {selection_name};\n"


### PR DESCRIPTION
fix for 2 bugs:
* prevent breaking the model.cfg by using classnames with illegal characters
* prevent zero vector as axisDir (affected p3d selections did disappear)